### PR TITLE
Use correct calling convention for GetTickCount on windows

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -1,7 +1,7 @@
 pub fn get_tick_count() -> u32 {
     cfgenius::cond! {
         if cfg(windows) {
-            extern "C" {
+            extern "stdcall" {
                 fn GetTickCount() -> u32;
             }
 


### PR DESCRIPTION
On Windows platforms, the crate links to `GetTickCount` as if it had the `C` calling convention, where like other Windows API functions it has the `stdcall` calling convention. While they are the same on 64-bit targets, on `i686-pc-windows-msvc` this leads to failure to build due to linker errors as they have [different name mangling conventions](https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170). Here is the linker error I get when testing a crate that depends on `jit-allocator` for target `i686-pc-windows-msvc`:

```txt
error: could not compile `closure-ffi` (test "test_explicit_alloc") due to 1 previous error
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.40.33807\\bin\\HostX64\\x86\\link.exe" "/NOLOGO" "/LARGEADDRESSAWARE" "/SAFESEH" "C:\\Users\\William\\AppData\\Local\\Temp\\rustcgTnKhZ\\symbols.o" "<23 object files omitted>" "<sysroot>\\lib\\rustlib\\i686-pc-windows-msvc\\lib/{libtest-*,libgetopts-*,libunicode_width-*,librustc_std_workspace_std-*}.rlib" "E:\\repos\\closure-ffi\\target\\i686-pc-windows-msvc\\debug\\deps/{libjit_allocator-bee11e48550f6d2a.rlib,libonce_cell-6027090906169c1f.rlib,libwinapi-5c0336da55792e2f.rlib,libcfgenius-f4eca3b55d21fa09.rlib,libintrusive_collections-4ec09561e60f98fc.rlib,libmemoffset-0dceaa5867d0c69e.rlib,liblibc-0c254d181a5d2e9c.rlib,liberrno-31cf3700dd6de730.rlib,libwindows_sys-9b8d2f8468b89555.rlib,libwindows_targets-b4968214d4db5b30.rlib}.rlib" "<sysroot>\\lib\\rustlib\\i686-pc-windows-msvc\\lib/{libstd-*,libpanic_unwind-*,libwindows_targets-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libunwind-*,libcfg_if-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "kernel32.lib" "kernel32.lib" "legacy_stdio_definitions.lib" "C:\\Users\\William\\.cargo\\registry\\src\\index.crates.io-1949cf8c6b5b557f\\windows_i686_msvc-0.52.6\\lib\\windows.0.52.0.lib" "kernel32.lib" "kernel32.lib" "advapi32.lib" "ntdll.lib" "userenv.lib" "ws2_32.lib" "dbghelp.lib" "/defaultlib:msvcrt" "/NXCOMPAT" "/LIBPATH:C:\\Users\\William\\.cargo\\registry\\src\\index.crates.io-1949cf8c6b5b557f\\windows_i686_msvc-0.52.6\\lib" "/OUT:E:\\repos\\closure-ffi\\target\\i686-pc-windows-msvc\\debug\\deps\\closure_ffi-874e08af59b90640.exe" "/OPT:REF,NOICF" "/DEBUG" "/PDBALTPATH:%_PDB%" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\libstd.natvis"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: libjit_allocator-bee11e48550f6d2a.rlib(jit_allocator-bee11e48550f6d2a.jit_allocator.38d8797f119d6955-cgu.3.rcgu.o) : error LNK2019: unresolved external symbol _GetTickCount referenced in function __ZN13jit_allocator2os14get_tick_count17h3f90320484066921E␍
          E:\repos\closure-ffi\target\i686-pc-windows-msvc\debug\deps\closure_ffi-874e08af59b90640.exe : fatal error LNK1120: 1 unresolved externals
```
Switching to the correct calling convention fixed the issue.